### PR TITLE
Fixed a small bug that caused errors on new v0.5.2 of DataFrames.jl

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -142,7 +142,9 @@ function query(q::String,conn::SQLiteDB=sqlitedb)
 		end
 	end
 	sqlite3_finalize(stmt)
-	return (conn.resultset = DataFrame(resultset,Index(colnames)))
+    
+	indices = DataFrames.Index(convert(Array{Symbol,1}, colnames))
+	return (conn.resultset = DataFrame(resultset,indices))
 end
 function createtable(input::TableInput,conn::SQLiteDB=sqlitedb;name::String="",delim::Char='\0',header::Bool=true,types::Array{DataType,1}=DataType[],infer::Bool=true)
 	conn == null_SQLiteDB && error("[sqlite]: A valid SQLiteDB was not specified (and no valid default SQLiteDB exists)")


### PR DESCRIPTION
Fixes this issue:

```
Index not defined
while loading In[0], in expression starting on line 1
 in query at /root/.julia/SQLite/src/SQLite.jl:145
 in query at /root/.julia/SQLite/src/SQLite.jl:84
```
