### PR TITLE
Create appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+environment:
+  matrix:
+# Releases
+  - JULIAVERSION: "stable/win32"
+  - JULIAVERSION: "stable/win64"
+# Nightlies
+  - JULIAVERSION: "download/win32"
+  - JULIAVERSION: "download/win64"
+
+install:
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile($("http://status.julialang.org/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.init(); Pkg.clone(pwd(), \"SQLite\"); Pkg.build(\"SQLite\")"
+
+test_script:
+  - C:\projects\julia\bin\julia test\runtests.jl


### PR DESCRIPTION
You like cross-platform testing, yeah? Who doesn't like cross-platform testing? See https://ci.appveyor.com/project/tkelman/sqlite-jl/build/1.0.2 for what this looks like. It's good for the sake of BinDeps and WinRPM to have more active packages running these regularly, so we can catch issues a little sooner - until PkgEvaluator runs cross-platform, anyway.

Signing up for an account on appveyor.com is pretty simple, if you haven't done it yet. After turning this on you'll also want to follow the instructions at http://github-multi-status.herokuapp.com to enable a webhook so Travis and AppVeyor can coexist on PR status indicators.
