### PR TITLE
Better sqlite types for Union{Missing, T}

### DIFF
--- a/src/Sink.jl
+++ b/src/Sink.jl
@@ -1,6 +1,9 @@
-sqlitetype(::Type{T}) where {T<:Integer} = "INT"
-sqlitetype(::Type{T}) where {T<:AbstractFloat} = "REAL"
-sqlitetype(::Type{T}) where {T<:AbstractString} = "TEXT"
+sqlitetype(::Type{T}) where {T<:Integer} = "INT NOT NULL"
+sqlitetype(::Type{T}) where {T<:Union{Missing, Integer}} = "INT"
+sqlitetype(::Type{T}) where {T<:AbstractFloat} = "REAL NOT NULL"
+sqlitetype(::Type{T}) where {T<:Union{Missing, AbstractFloat}} = "REAL"
+sqlitetype(::Type{T}) where {T<:AbstractString} = "TEXT NOT NULL"
+sqlitetype(::Type{T}) where {T<:Union{Missing, AbstractString}} = "TEXT"
 sqlitetype(::Type{Missing}) = "NULL"
 sqlitetype(x) = "BLOB"
 


### PR DESCRIPTION
Fixes #136

`sqlitetype` changed to assign `{T} NOT NULL` for julia types that are not a `Union{Missing, T}` type and `{T}` to types that are. For example, 

```julia
julia> SQLite.sqlitetype(Union{Missing, Float64})     # Used to return "BLOB"
"REAL"

julia> SQLite.sqlitetype(Float64)       # Used to return "REAL"
"REAL NOT NULL"
``` 