### PR TITLE
Update REQUIRE to include Missings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ DataStreams 0.3.0
 DataFrames 0.11.0
 WeakRefStrings 0.4.0
 LegacyStrings
+Missings


### PR DESCRIPTION
Missings is used in the package, but isn't in the REQUIRE causing precompilation errors.