### PR TITLE
fix docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,24 @@ os:
 
 julia:
   - 1.0
+  - 1.1
   - nightly
+
+env:
+  - JULIA_PROJECT="@."
 
 notifications:
   email: false
 
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("SQLite")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-  - julia -e 'using Pkg; Pkg.add("Documenter")'
-  - julia -e 'using Pkg; cd(Pkg.dir("SQLite")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'ENV["TRAVIS_JULIA_VERSION"] != "1.1" && ENV["TRAVIS_OS_NAME"] != "linux" && exit(); using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.1
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.build("SQLite")'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
+
+[compat]
+Documenter = "~0.22"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,6 @@ using Documenter, SQLite
 
 makedocs(
     modules = [SQLite],
-    format = :html,
     sitename = "SQLite.jl",
     pages = ["Home" => "index.md"]
 )
@@ -10,8 +9,4 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaDB/SQLite.jl.git",
     target = "build",
-    deps = nothing,
-    make = nothing,
-    julia = "1.0",
-    osname = "linux"
 )


### PR DESCRIPTION
Hi!

I found this on travis logs for SQLite:

```
$ julia -e 'using Pkg; cd(Pkg.dir("SQLite")); include(joinpath("docs", "make.jl"))'
┌ Warning: `Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import SQLite; joinpath(dirname(pathof(SQLite)), "..", paths...)`.
└ @ Pkg.API /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Pkg/src/API.jl:480
┌ Warning: `format = :html` is deprecated, use `format = Documenter.HTML()` instead.
│   caller = ip:0x0
└ @ Core :-1
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
┌ Warning: 16 docstrings potentially missing:
│ 
│     SQLite.tables :: Union{Tuple{DB}, Tuple{DB,Any}}
│     SQLite.transaction
│     SQLite.dropindex! :: Tuple{SQLite.DB,AbstractString}
│     SQLite.rollback
│     SQLite.clear! :: Tuple{SQLite.Stmt}
│     SQLite.indices :: Union{Tuple{DB}, Tuple{DB,Any}}
│     SQLite.drop! :: Tuple{SQLite.DB,AbstractString}
│     SQLite.execute!
│     SQLite.columns :: Union{Tuple{DB,AbstractString}, Tuple{DB,AbstractString,Any}}
│     SQLite.createindex! :: Union{Tuple{S}, Tuple{DB,AbstractString,AbstractString,Union{AbstractArray{S,1}, S}}} where S<:AbstractString
│     SQLite.esc_id
│     SQLite.DB
│     SQLite.bind!
│     SQLite.removeduplicates! :: Union{Tuple{T}, Tuple{Any,AbstractString,AbstractArray{T,N} where N}} where T<:AbstractString
│     SQLite.commit
│     SQLite.Stmt
└ @ Documenter.DocChecks ~/.julia/packages/Documenter/G5Sup/src/DocChecks.jl:50
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
┌ Warning: the `julia` keyword argument to `Documenter.deploydocs` is removed. Use Travis Build Stages for determining from where to deploy instead. See the section about Hosting in the Documenter manual for more details.
│   caller = ip:0x0
└ @ Core :-1
[ Info: skipping docs deployment.
```

This PR will try to fix docs deployment. Please, feel free to close this if you wanna go in another direction.