### PR TITLE
fix docs deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,6 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/JuliaDB/SQLite.jl.git",
+    repo = "github.com/JuliaDatabases/SQLite.jl.git",
     target = "build",
 )


### PR DESCRIPTION
So, it didn't work out, but it is almost there! :smile: 

The repo URL is wrong, so this PR should fix that.

Another thing you need to do is to set the `DOCUMENTER_KEY` environment variable in travis, as described in https://juliadocs.github.io/Documenter.jl/stable/man/hosting/.