### PR TITLE
Add spaces to parameter list for clarity

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,9 +37,13 @@ SQLite.load!
   > In SQLite, wherever it is valid to include a string literal, one can use a parameter in one of the following forms:
 
   > ?
+  >
   > ?NNN
+  >
   > :AAA
+  >
   > $AAA
+  >
   > @AAA
 
   > In the examples above, NNN is an integer value and AAA is an identifier. A parameter initially has a value of NULL. Prior to calling sqlite3_step() for the first time or immediately after sqlite3_reset(), the application can invoke one of the sqlite3_bind() interfaces to attach values to the parameters. Each call to sqlite3_bind() overrides prior bindings on the same parameter.


### PR DESCRIPTION
At first read, I didn't realize these were all separate possibilities since they appeared on one line on the web docs:


<img width="656" alt="image" src="https://user-images.githubusercontent.com/8291800/62429950-2c997800-b751-11e9-87f4-29514d158268.png">
