### PR TITLE
Fix signature of DBInterface.prepare

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -69,13 +69,13 @@ end
 DBInterface.lastrowid(q::Query) = last_insert_rowid(q.stmt.db)
 
 """
-    DBInterface.prepare(db::SQLite.DB, sql::String)
+    DBInterface.prepare(db::SQLite.DB, sql::AbstractString)
 
 Prepare an SQL statement given as a string in the sqlite database; returns an `SQLite.Stmt` compiled object.
 See `DBInterface.execute`(@ref) for information on executing a prepared statement and passing parameters to bind.
 A `SQLite.Stmt` object can be closed (resources freed) using `DBInterface.close!`(@ref).
 """
-DBInterface.prepare(db::DB, sql::String) = Stmt(db, sql)
+DBInterface.prepare(db::DB, sql::AbstractString) = Stmt(db, sql)
 
 """
     DBInterface.execute(db::SQLite.DB, sql::String, [params])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,6 +258,12 @@ r = DBInterface.execute(db, "SELECT * FROM T") |> columntable
 @test r[1][2] == 2
 @test r[1][3] == 3
 
+
+r = DBInterface.execute(db, strip("   SELECT * FROM T  ")) |> columntable
+@test r[1][1] == 1
+@test r[1][2] == 2
+@test r[1][3] == 3
+
 @test SQLite.esc_id(["1", "2", "3"]) == "\"1\",\"2\",\"3\""
 
 SQLite.createindex!(db, "T", "x", "x_index"; unique=false)


### PR DESCRIPTION
I chnaged the signature of the DBInterface.prepare function to receive AbstractString istead of Strings. I faced the following error:

```
julia> using SQLite
julia> using DBInterface
julia> a = SQLite.DB("a")
julia> DBInterface.prepare(a, strip("   SELECT * FROM table  "))
ERROR: DBInterface.NotImplementedError("`DBInterface.prepare` not implemented for `SQLite.DB`")
Stacktrace:
 [1] prepare(::SQLite.DB, ::SubString{String}) at /home/luciano/.julia/packages/DBInterface/EUwXt/src/DBInterface.jl:41
 [2] top-level scope at REPL[10]:1

```