### PR TITLE
Set busy_timeout

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -541,4 +541,15 @@ function enable_load_extension(db, enable::Bool=true)
    ccall((:sqlite3_enable_load_extension, SQLite.libsqlite), Cint, (Ptr{Cvoid}, Cint), db.handle, enable)
 end
 
+"""
+    SQLite.busy_timeout(db, ms::Integer=0)
+
+Set a busy handler that sleeps for a specified amount of milliseconds  when a table is locked. After at least ms milliseconds of sleeping, the handler will return 0, causing sqlite to return SQLITE_BUSY.
+"""
+function busy_timeout(db, ms::Integer=0)
+    sqlite3_busy_timeout(db.handle, ms)
+end
+
+
+
 end # module

--- a/src/api.jl
+++ b/src/api.jl
@@ -114,6 +114,15 @@ end
 # SQLITE_API int sqlite3_bind_zeroblob(sqlite3_stmt*, int, int n);
 # SQLITE_API int sqlite3_bind_value(sqlite3_stmt*, int, const sqlite3_value*);
 
+
+# SQLITE_API int sqlite3_busy_timeout(sqlite3*, int ms);
+function sqlite3_busy_timeout(db::Ptr{Cvoid}, ms)
+    @NULLCHECK db
+    return ccall( (:sqlite3_busy_timeout, libsqlite),
+        Cint, (Ptr{Cvoid}, Cint), 
+        db, ms)
+end
+
 function sqlite3_clear_bindings(stmt::Ptr{Cvoid})
     return ccall( (:sqlite3_clear_bindings, libsqlite),
         Cint, (Ptr{Cvoid},),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -314,4 +314,7 @@ tbl3 = (c = [7, 8, 9], a = [4, 5, 6])
 @test_throws ErrorException SQLite.load!(tbl3, db, "data")
 
 
+# Test busy_timeout
+@test SQLite.busy_timeout(db, 300) == 0
+
 end # @testset


### PR DESCRIPTION
This option is often set when connecting to the db, not sure what's the best way to expose this functionality, here is a suggestion for adding a function to set it later.

https://www.sqlite.org/c3ref/busy_timeout.html