### PR TITLE
Support DBInterface.execute(f, stmt) method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 BinaryProvider = "0.5"
-DBInterface = "2.3"
+DBInterface = "2.4"
 SQLite_jll = "3"
 Tables = "1"
 WeakRefStrings = "0.4,0.5,0.6"

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -27,6 +27,11 @@ function reset!(q::Query)
     return
 end
 
+function DBInterface.close!(q::Query)
+    _st = _stmt_safe(q.stmt)
+    (_st !== nothing) && sqlite3_reset(_st.handle)
+end
+
 function done(q::Query)
     st = q.status[]
     if st == SQLITE_DONE

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,9 +66,23 @@ ds = DBInterface.execute(db, "SELECT name FROM sqlite_master WHERE type='table';
 results1 = SQLite.tables(db)
 @test isequal(ds, results1)
 
-results = DBInterface.execute(db, "SELECT * FROM Employee;") |> columntable
-@test length(results) == 15
-@test length(results[1]) == 8
+@testset "DBInterface.execute([f])" begin
+    # pipe approach
+    results = DBInterface.execute(db, "SELECT * FROM Employee;") |> columntable
+    @test length(results) == 15
+    @test length(results[1]) == 8
+    # callable approach
+    @test isequal(DBInterface.execute(columntable, db, "SELECT * FROM Employee"), results)
+    employees_stmt = DBInterface.prepare(db, "SELECT * FROM Employee")
+    @test isequal(columntable(DBInterface.execute(employees_stmt)), results)
+    @test isequal(DBInterface.execute(columntable, employees_stmt), results)
+    @testset "throwing from f()" begin
+        f(::SQLite.Query) = error("I'm throwing!")
+        @test_throws ErrorException DBInterface.execute(f, employees_stmt)
+        @test_throws ErrorException DBInterface.execute(f, db, "SELECT * FROM Employee")
+    end
+    DBInterface.close!(employees_stmt)
+end
 
 DBInterface.execute(db, "create table temp as select * from album")
 DBInterface.execute(db, "alter table temp add column colyear int")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,12 @@ db = DBInterface.connect(SQLite.DB, dbfile2)
 # syntax correct, table missing
 @test_throws SQLiteException DBInterface.execute(db, "SELECT name FROM sqlite_nomaster WHERE type='table';")
 
+@testset "close!(query)" begin
+    qry = DBInterface.execute(db, "SELECT name FROM sqlite_master WHERE type='table';")
+    DBInterface.close!(qry)
+    DBInterface.close!(qry) # test it doesn't throw on double-close
+end
+
 ds = DBInterface.execute(db, "SELECT name FROM sqlite_master WHERE type='table';") |> columntable
 @test length(ds) == 1
 @test keys(ds) == (:name,)


### PR DESCRIPTION
The PR implements adds `DBInterface.close!(::Query)` required by `DBInterface.execute(f, stmt)` introduced in JuliaDatabases/DBInterface.jl#35 and adds tests to make sure that `DBIntreface.execute(f, ...)` methods work.
