### PR TITLE
Correct scheme for empty Query

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -10,6 +10,9 @@ struct Query
     lookup::Dict{Symbol, Int}
 end
 
+# check if the query has no (more) rows
+Base.isempty(q::Query) = q.status[] == SQLITE_DONE
+
 struct Row <: Tables.AbstractRow
     q::Query
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,11 @@ results1 = SQLite.tables(db)
     DBInterface.close!(employees_stmt)
 end
 
+@testset "isempty(::Query)" begin
+    @test !DBInterface.execute(isempty, db, "SELECT * FROM Employee")
+    @test DBInterface.execute(isempty, db, "SELECT * FROM Employee WHERE FirstName='Joanne'")
+end
+
 DBInterface.execute(db, "create table temp as select * from album")
 DBInterface.execute(db, "alter table temp add column colyear int")
 DBInterface.execute(db, "update temp set colyear = 2014")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,6 +89,18 @@ end
     @test DBInterface.execute(isempty, db, "SELECT * FROM Employee WHERE FirstName='Joanne'")
 end
 
+@testset "empty query has correct schema and return type" begin
+    empty_scheme = DBInterface.execute(Tables.schema, db, "SELECT * FROM Employee WHERE FirstName='Joanne'")
+    all_scheme = DBInterface.execute(Tables.schema, db, "SELECT * FROM Employee WHERE FirstName='Joanne'")
+    @test empty_scheme.names == all_scheme.names
+    @test all(ea -> ea[1] <: ea[2], zip(empty_scheme.types, all_scheme.types))
+
+    empty_tbl = DBInterface.execute(columntable, db, "SELECT * FROM Employee WHERE FirstName='Joanne'")
+    all_tbl = DBInterface.execute(columntable, db, "SELECT * FROM Employee")
+    @test propertynames(empty_tbl) == propertynames(all_tbl)
+    @test all(col -> eltype(empty_tbl[col]) >: eltype(all_tbl[col]), propertynames(all_tbl))
+end
+
 DBInterface.execute(db, "create table temp as select * from album")
 DBInterface.execute(db, "alter table temp add column colyear int")
 DBInterface.execute(db, "update temp set colyear = 2014")


### PR DESCRIPTION
At the moment if the *Query* is empty, its scheme would be empty too, although the *Query.names* and *Query.types* are already properly initialized. This is inconvenient, since the user code then would have to check whether the result is empty before accessing any columns.

The PR fixes that: if the *Query* is empty, the scheme would be based on *Query.names* and *Query.types*, otherwise it will fall back to using the values of the actual result.

Also the *Base.isempty(::Query)* is added (needed for the schema fix).
And *juliatype(string)* is taught to recognize more declared column types (e.g. in future we might support *DATETIME* properly).
