### PR TITLE
Improve juliatype()

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -345,6 +345,7 @@ end
  #int sqlite3_bind_zeroblob(sqlite3_stmt*, int, int n);
  #int sqlite3_bind_value(sqlite3_stmt*, int, const sqlite3_value*);
 
+# get julia type for given column of the given statement
 function juliatype(handle, col)
     t = SQLite.sqlite3_column_decltype(handle, col)
     if t != C_NULL
@@ -360,12 +361,14 @@ function juliatype(handle, col)
     end
 end
 
+# convert SQLite stored type into Julia equivalent
 juliatype(x::Integer) =
     x == SQLITE_INTEGER ? Int :
     x == SQLITE_FLOAT ? Float64 :
     x == SQLITE_TEXT ? String :
     Any
 
+# convert SQLite declared type into Julia equivalent
 function juliatype(typestr::AbstractString)
     typeuc = uppercase(typestr)
     if typeuc in ("INTEGER", "INT")

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -373,7 +373,7 @@ function juliatype(typestr::AbstractString)
     typeuc = uppercase(typestr)
     if typeuc in ("INTEGER", "INT")
         return Int
-    elseif typeuc in ("NUMERIC", "REAL")
+    elseif typeuc in ("NUMERIC", "REAL", "FLOAT")
         return Float64
     elseif typeuc == "TEXT"
         return String
@@ -381,7 +381,9 @@ function juliatype(typestr::AbstractString)
         return Any
     elseif typeuc == "DATETIME"
         return Any # FIXME
-    elseif occursin(r"^NVARCHAR\(\d+\)$", typeuc)
+    elseif typeuc == "TIMESTAMP"
+        return Any # FIXME
+    elseif occursin(r"^(?:N?VAR)?CHAR\(\d+\)$", typeuc)
         return String
     elseif occursin(r"^NUMERIC\(\d+,\d+\)$", typeuc)
         return Float64


### PR DESCRIPTION
Suppresses type conversion warnings mentioned in #219 and #231.
I've also clarified the warning message, so people can see which Julia types will be actually used for the data.

However, the types logic in SQLite is more complex (see [SQLite types docs](https://www.sqlite.org/datatype3.html)).
E.g. *NUMERIC* could be integer or float depending on the actual values stored, and when importing data into julia the actual Julia column type may differ from what `juliatype()` provides.