### PR TITLE
By default, make query column names unique

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -458,7 +458,7 @@ end
 execute(stmt::Stmt, params::DBInterface.StatementParams) =
     execute(stmt.db, _stmt(stmt), params)
 
-execute(stmt::Stmt; kwargs...) = execute(stmt, kwargs.data)
+execute(stmt::Stmt; kwargs...) = execute(stmt, values(kwargs))
 
 function execute(db::DB, sql::AbstractString, params::DBInterface.StatementParams)
      # prepare without registering _Stmt in DB
@@ -470,7 +470,7 @@ function execute(db::DB, sql::AbstractString, params::DBInterface.StatementParam
     end
 end
 
-execute(db::DB, sql::AbstractString; kwargs...) = execute(db, sql, kwargs.data)
+execute(db::DB, sql::AbstractString; kwargs...) = execute(db, sql, values(kwargs))
 
 """
     SQLite.esc_id(x::Union{AbstractString,Vector{AbstractString}})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -424,6 +424,11 @@ tbl3 = (c = [7, 8, 9], a = [4, 5, 6])
 # Test busy_timeout
 @test SQLite.busy_timeout(db, 300) == 0
 
+# 253, ensure query column names are unique by default
+db = SQLite.DB()
+res = DBInterface.execute(db, "select 1 as x2, 2 as x2") |> columntable
+@test res == (x2 = [1], x2_1 = [2])
+
 @testset "load!()/drop!() table name escaping" begin
     tbl = (a = [1, 2, 3], b = ["a", "b", "c"])
     SQLite.load!(tbl, db, "escape 10.0%")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -426,8 +426,8 @@ tbl3 = (c = [7, 8, 9], a = [4, 5, 6])
 
 # 253, ensure query column names are unique by default
 db = SQLite.DB()
-res = DBInterface.execute(db, "select 1 as x2, 2 as x2") |> columntable
-@test res == (x2 = [1], x2_1 = [2])
+res = DBInterface.execute(db, "select 1 as x2, 2 as x2, 3 as x2, 4 as x2_2") |> columntable
+@test res == (x2 = [1], x2_1 = [2], x2_2 = [3], x2_2_1 = [4])
 
 @testset "load!()/drop!() table name escaping" begin
     tbl = (a = [1, 2, 3], b = ["a", "b", "c"])


### PR DESCRIPTION
Fixes #253. Most data formats have requirements around column name
uniqueness, including DataFrames.jl. The proposed changes here ensure
query result columns are unique by default, while still allowing column
names to be duplicated if they pass `allowduplicates=true` to
`DBInterface.execute`.