### PR TITLE
Ensure schema-less tables have all rows respected in load!

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -506,3 +506,25 @@ end
 end
 
 end # @testset
+
+struct UnknownSchemaTable
+end
+
+Tables.isrowtable(::Type{UnknownSchemaTable}) = true
+Tables.rows(x::UnknownSchemaTable) = x
+Base.length(x::UnknownSchemaTable) = 3
+Base.iterate(::UnknownSchemaTable, st=1) = st == 4 ? nothing : ((a=1, b=2, c=3), st + 1)
+
+@testset "misc" begin
+
+# https://github.com/JuliaDatabases/SQLite.jl/issues/259
+db = SQLite.DB()
+SQLite.load!(UnknownSchemaTable(), db, "tbl")
+tbl = DBInterface.execute(db, "select * from tbl") |> columntable
+@test tbl == (
+    a = [1, 1, 1],
+    b = [2, 2, 2],
+    c = [3, 3, 3]
+)
+
+end


### PR DESCRIPTION
Fixes #259. This one feels bad. For the schema-less input table case, we
iterated the first row to get the names so we could do some schema
validation, but then threw the row away, assuming that as we iterate
later, we would somehow get all the rows anyway. That probably was fine
in cases like a DataFrame, where iteration would correctly restart, but
for most schema-less tables, it's not uncommon to be a stateful iterator
that is forward-pass only (like `SQLite.Query`!). We fix this here by
ensuring that row stays intact and is inserted before iterating further
rows.