### PR TITLE
Ensure rows are only valid while currently being iterated

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -540,4 +540,11 @@ tbl = DBInterface.execute(db, "select * from tbl") |> columntable
     c = [3, 3, 3]
 )
 
+# https://github.com/JuliaDatabases/SQLite.jl/issues/251
+q = DBInterface.execute(db, "select * from tbl")
+row, st = iterate(q)
+@test row.a == 1 && row.b == 2 && row.c == 3
+row2, st = iterate(q, st)
+@test_throws ArgumentError row.a
+
 end


### PR DESCRIPTION
Fixes #251 amongst other issues. This PR makes `SQLite.Row` explicitly
error when values are attempted to be accessed and it's not the
currently iterated row. It borrows the idea from the MySQL.jl package,
which as a similar "sync" of row numbers between the `Row` and `Query`
objects.