### PR TITLE
Convert DB input to String to try and avoid any weirdness

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -78,7 +78,7 @@ mutable struct DB <: DBInterface.Connection
 
     function DB(f::AbstractString)
         handle = Ref{DBHandle}()
-        f = isempty(f) ? f : expanduser(f)
+        f = String(isempty(f) ? f : expanduser(f))
         if @OK sqlite3_open(f, handle)
             db = new(f, handle[], Dict{StmtHandle, _Stmt}(), 0)
             finalizer(_close, db)


### PR DESCRIPTION
As reported in #265, perhaps the sqlite library doesn't like SubStrings
sometimes. It's a pretty easy fix to just convert to String before
passing to sqlite_open.