### PR TITLE
Allow sqldeserialize to return non-T to allow value/schema mismatch

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -414,7 +414,7 @@ function sqlitevalue(::Type{T}, handle, col) where {T}
     b = sqlite3_column_bytes(handle, col)
     buf = zeros(UInt8, b) # global const?
     unsafe_copyto!(pointer(buf), blob, b)
-    r = sqldeserialize(buf)::T
+    r = sqldeserialize(buf)
     return r
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -559,4 +559,11 @@ tbl = DBInterface.execute(db, "select * from tmp") |> columntable
     c = [6]
 )
 
+db = SQLite.DB()
+DBInterface.execute(db, "create table tmp ( x TEXT )")
+DBInterface.execute(db, "insert into tmp values (?)", (nothing,))
+DBInterface.execute(db, "insert into tmp values (?)", (:a,))
+tbl = DBInterface.execute(db, "select x from tmp") |> columntable
+@test isequal(tbl.x, [missing, :a])
+
 end


### PR DESCRIPTION
Fixes #244. Last time we refactored SQLite.Query, we took out any strict
schema enforcement, mainly by defining the `Tales.schema` of
`SQLite.Query` to be `nothing`, thus allowing sinks to "discover" the
schema dynamically, which better fits the sqlite data type model. As
reported in #244, however, we missed a case where we pass in the
declared column's type to `sqlitevalue` and then `sqldeserialize` was
being forced to assert that what it deserialized was a value of that
type. That isn't generally possible, since the declared sqlite types are
such a small subset of what we'll technically serialize/deserialize with
custom Julia values. By removing the type assertion, we allow
sqldeserialize to do its job and sqlitevalue to return whatever gets
deserialized.