### PR TITLE
Support DBInterface.jl v2.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SQLite"
 uuid = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
@@ -17,7 +17,7 @@ WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 BinaryProvider = "0.5"
-DBInterface = "2.4"
+DBInterface = "2.5"
 SQLite_jll = "3"
 Tables = "1"
 WeakRefStrings = "0.4,0.5,0.6,1"

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -177,6 +177,8 @@ end
 # it from the db.stmts collection
 _finalize(stmt::Stmt) = DBInterface.close!(stmt)
 
+DBInterface.getconnection(stmt::Stmt) = stmt.db
+
 # explicitly close prepared statement
 function DBInterface.close!(stmt::Stmt)
     _st = _stmt_safe(stmt)
@@ -548,6 +550,8 @@ function transaction(db::DB, mode="DEFERRED")
         execute(db, "SAVEPOINT $(mode);")
     end
 end
+
+DBInterface.transaction(f, db::DB) = transaction(f, db)
 
 @inline function transaction(f::Function, db::DB)
     # generate a random name for the savepoint

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -238,7 +238,7 @@ function load!(sch::Tables.Schema, rows, db::DB, name::AbstractString, db_tablei
     kind = replace ? "REPLACE" : "INSERT"
     stmt = _Stmt(db, "$kind INTO $(esc_id(string(name))) ($columns) VALUES ($params)")
     # start a transaction for inserting rows
-    transaction(db) do
+    DBInterface.transaction(db) do
         if row === nothing
             state = iterate(rows)
             state === nothing && return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -566,4 +566,16 @@ DBInterface.execute(db, "insert into tmp values (?)", (:a,))
 tbl = DBInterface.execute(db, "select x from tmp") |> columntable
 @test isequal(tbl.x, [missing, :a])
 
+db = SQLite.DB()
+DBInterface.execute(db, "create table tmp (a integer, b integer, c integer)")
+stmt = DBInterface.prepare(db, "INSERT INTO tmp VALUES(?, ?, ?)")
+tbl = (
+    a = [1, 1, 1],
+    b = [3, 4, 5],
+    c = [4, 5, 6]
+)
+DBInterface.executemany(stmt, tbl)
+tbl2 = DBInterface.execute(db, "select * from tmp") |> columntable
+@test tbl == tbl2
+
 end


### PR DESCRIPTION
DBInterface.jl now supports overloading `DBInterface.transaction` that
is now used in `DBInterface.executemany` to wrap multiple `execute`
calls in transactions for efficiency. This speeds up the use of
`executemany` on SQLite prepared statements, as reported as slow in