### PR TITLE
Implement DBInterface.getconnection

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -187,6 +187,8 @@ function DBInterface.close!(stmt::Stmt)
     return stmt
 end
 
+DBInterface.getconnection(stmt::Stmt) = stmt.db
+
 sqliteprepare(db::DB, sql::AbstractString, stmt::Ref{StmtHandle}, null::Ref{StmtHandle}) =
     @CHECK db sqlite3_prepare_v2(db.handle, sql, stmt, null)
 


### PR DESCRIPTION
As of version 2.5.0 (commit https://github.com/JuliaDatabases/DBInterface.jl/commit/8d2fd10072e6e28a55244f85c8c800ad1556eac2), DBInterface uses `getconnection` in `executemany`, which requires implementation.