### PR TITLE
Report the failing INSERT when `load!()` errors

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -38,6 +38,12 @@ function sqlite3_prepare16_v2(handle::Ptr{Cvoid}, query::AbstractString, stmt, u
         Cint, (Ptr{Cvoid}, Ptr{UInt16}, Cint, Ptr{Cvoid}, Ptr{Cvoid}),
         handle, query, sizeof(query), stmt, unused)
 end
+function sqlite3_expanded_sql(stmt::Ptr{Cvoid})
+    @NULLCHECK stmt
+    return ccall( (:sqlite3_expanded_sql, libsqlite),
+        Ptr{UInt8}, (Ptr{Cvoid},), stmt)
+end
+sqlite3_free(ptr::Ptr{Cvoid}) = ccall( (:sqlite3_free, libsqlite), Cvoid, (Ptr{Cvoid},), ptr)
 function sqlite3_finalize(stmt::Ptr{Cvoid})
     @NULLCHECK stmt
     return ccall( (:sqlite3_finalize, libsqlite),

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -252,7 +252,7 @@ function load!(sch::Tables.Schema, rows, db::DB, name::AbstractString, db_tablei
             if r == SQLITE_DONE
                 sqlite3_reset(stmt.handle)
             elseif r != SQLITE_ROW
-                e = sqliteexception(db)
+                e = sqliteexception(db, stmt)
                 sqlite3_reset(stmt.handle)
                 throw(e)
             end


### PR DESCRIPTION
SQLite3 provides `sqlite3_expanded_sql()` to retrieve the _as-bound_ statement text; this makes it possible to report the exact failing INSERT when `load!()` fails, e.g. due to a `PRIMARY KEY` violation.

I found it very useful when debugging all the various ways a pre-existing data source violated its own nominal schema.