### PR TITLE
Allow selection of constraint conflict resolution algorithm in SQLite.load!

### DIFF
--- a/src/tables.jl
+++ b/src/tables.jl
@@ -214,8 +214,8 @@ function tableinfo(db::DB, name::AbstractString)
 end
 
 """
-    source |> SQLite.load!(db::SQLite.DB, tablename::String; temp::Bool=false, ifnotexists::Bool=false, replace::Bool=false, or::Union{String, Nothing} = nothing, analyze::Bool=false)
-    SQLite.load!(source, db, tablename; temp=false, ifnotexists=false, replace::Bool=false, or::Union{String, Nothing} = nothing, analyze::Bool=false)
+    source |> SQLite.load!(db::SQLite.DB, tablename::String; temp::Bool=false, ifnotexists::Bool=false, replace::Bool=false, on_conflict::Union{String, Nothing} = nothing, analyze::Bool=false)
+    SQLite.load!(source, db, tablename; temp=false, ifnotexists=false, replace::Bool=false, on_conflict::Union{String, Nothing} = nothing, analyze::Bool=false)
 
 Load a Tables.jl input `source` into an SQLite table that will be named `tablename` (will be auto-generated if not specified).
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -933,6 +933,7 @@ end
         "tmp",
     )
     SQLite.load!(UnknownSchemaTable(), db, "tmp"; replace = true)
+    SQLite.load!(UnknownSchemaTable(), db, "tmp"; or = "IGNORE")
     tbl = DBInterface.execute(db, "select * from tmp") |> columntable
     @test tbl == (a = [1], b = [5], c = [6])
 


### PR DESCRIPTION
[#263](https://github.com/JuliaDatabases/SQLite.jl/pull/263) allows the choice between INSERT or REPLACE for the load! function. However, there are several other [constraint conflict resolution algorithms](https://sqlite.org/lang_conflict.html) listed in the SQLite specification, which could also be supported.
This pull request adds another keyword argument `or::Union{String, Nothing}` to the load! function, which is set to `nothing` by default. Valid values include `nothing`, "ROLLBACK", "ABORT", "FAIL", "IGNORE" and "REPLACE". For backwards compatibility, the `replace` keyword argument is left intact. If the new argument is set to its default value of `nothing`, the old keyword arbitrates between INSERT and REPLACE.