### PR TITLE
add test for query with strict keyword

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SQLite"
 uuid = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>", "JuliaData Contributors"]
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,6 +222,21 @@ end
         end
     end
 
+    @testset "strict=true || isempty(query)" begin
+        setup_clean_test_db() do db
+            empty_query =
+                DBInterface.execute(db, "SELECT * FROM Employee LIMIT 0")
+            sch = Tables.schema(empty_query)
+            @test sch == Tables.Schema(empty_query.names, empty_query.types)
+            strict_query =
+                DBInterface.execute(db, "SELECT * FROM Employee"; strict = true)
+            @test strict_query isa SQLite.Query{true}
+            sch2 = Tables.schema(strict_query)
+            @test sch2 == Tables.Schema(strict_query.names, strict_query.types)
+            @test sch.names == sch2.names
+        end
+    end
+
     @testset "empty query has correct schema and return type" begin
         setup_clean_test_db() do db
             empty_scheme = DBInterface.execute(


### PR DESCRIPTION

kwargs in DBInterface will transform to params, therefore strict will be always false in SQLite 1.6.0