### PR TITLE
relax bind! Vector{UInt8} -> AbstractVector{UInt8}

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -346,7 +346,17 @@ function bind!(stmt::Stmt, i::Integer, val::Bool)
     stmt.params[i] = val
     @CHECK stmt.db C.sqlite3_bind_int(_get_stmt_handle(stmt), i, Int32(val))
 end
-function bind!(stmt::Stmt, i::Integer, val::AbstractVector{UInt8})
+function bind!(stmt::Stmt, i::Integer, val::Vector{UInt8})
+    stmt.params[i] = val
+    @CHECK stmt.db C.sqlite3_bind_blob(
+        _get_stmt_handle(stmt),
+        i,
+        val,
+        sizeof(val),
+        C.SQLITE_STATIC,
+    )
+end
+function bind!(stmt::Stmt, i::Integer, val::Base.ReinterpretArray{UInt8, 1, T, <:DenseVector{T}, false}) where T
     stmt.params[i] = val
     @CHECK stmt.db C.sqlite3_bind_blob(
         _get_stmt_handle(stmt),

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -361,7 +361,7 @@ function bind!(stmt::Stmt, i::Integer, val::Base.ReinterpretArray{UInt8, 1, T, <
     @CHECK stmt.db C.sqlite3_bind_blob(
         _get_stmt_handle(stmt),
         i,
-        val,
+        pointer(val),
         sizeof(eltype(val)) * length(val),
         C.SQLITE_STATIC,
     )

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -346,7 +346,7 @@ function bind!(stmt::Stmt, i::Integer, val::Bool)
     stmt.params[i] = val
     @CHECK stmt.db C.sqlite3_bind_int(_get_stmt_handle(stmt), i, Int32(val))
 end
-function bind!(stmt::Stmt, i::Integer, val::Vector{UInt8})
+function bind!(stmt::Stmt, i::Integer, val::AbstractVector{UInt8})
     stmt.params[i] = val
     @CHECK stmt.db C.sqlite3_bind_blob(
         _get_stmt_handle(stmt),

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -362,7 +362,7 @@ function bind!(stmt::Stmt, i::Integer, val::Base.ReinterpretArray{UInt8, 1, T, <
         _get_stmt_handle(stmt),
         i,
         val,
-        sizeof(val),
+        sizeof(eltype(val)) * length(val),
         C.SQLITE_STATIC,
     )
 end

--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -361,7 +361,7 @@ function bind!(stmt::Stmt, i::Integer, val::Base.ReinterpretArray{UInt8, 1, T, <
     @CHECK stmt.db C.sqlite3_bind_blob(
         _get_stmt_handle(stmt),
         i,
-        pointer(val),
+        Ref(val, 1),
         sizeof(eltype(val)) * length(val),
         C.SQLITE_STATIC,
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -906,6 +906,24 @@ end
         close(db)
         rm(dbfile)
     end
+
+    @testset "ReinterpretArray" begin
+        binddb = SQLite.DB()
+        DBInterface.execute(
+            binddb,
+            "CREATE TABLE temp (b BLOB)",
+        )
+        DBInterface.execute(
+            binddb,
+            "INSERT INTO temp VALUES (?)",
+            [reinterpret(UInt8, [0x6f46, 0x426f, 0x7261]),],
+        )
+        rr = DBInterface.execute(rowtable, binddb, "SELECT b FROM temp")
+        @test length(rr) == 1
+        r = first(rr)
+        @test r.b == codeunits("FooBar")
+        @test typeof.(Tuple(r)) == (Vector{UInt8},)
+    end
 end # @testset
 
 struct UnknownSchemaTable end


### PR DESCRIPTION
This allows zero-copy writes e.g. for ReinterpretArrays.

Do you want this to be tested explicitly?