### PR TITLE
Add backup API with configurable sleep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SQLite"
 uuid = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
-version = "1.7.1"
+version = "1.8.0"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>", "JuliaData Contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary
- add SQLite.backup helper with configurable sleep for busy/locked retries
- implement backup retry loop matching sqlite backup guidance
- add coverage for backup to file from in-memory db

## Test plan
- julia --project=. test/runtests.jl