### PR TITLE
Map DATETIME/TIMESTAMP declared types to String instead of falling back to stored type

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -527,10 +527,8 @@ function juliatype(decl_typestr::AbstractString, default::Type = Any)
         return String
     elseif typeuc == "BLOB"
         return Any
-    elseif typeuc == "DATETIME"
-        return default # FIXME
-    elseif typeuc == "TIMESTAMP"
-        return default # FIXME
+    elseif typeuc in ("DATETIME", "TIMESTAMP")
+        return String
     elseif occursin(
         r"^N?V?A?R?Y?I?N?G?\s*CHARA?C?T?E?R?T?E?X?T?\s*\(?\d*\)?$"i,
         typeuc,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -843,7 +843,7 @@ end
         tbl1 = (a = [1, 2, 3], b = [4, 5, 6])
         SQLite.load!(tbl1, db, "data_default")
         SQLite.load!(tbl1, db, "data_strict", strict=true)
-        
+
         tbl2 = (a = ["a", "b", "c"], b=[7, 8, 9])
         SQLite.load!(tbl2, db, "data_default")
         @test_throws SQLiteException SQLite.load!(tbl2, db, "data_strict")
@@ -1161,4 +1161,43 @@ end
         db_b,
         "select myfunc(1) as x",
     )
+
+    # DATETIME and TIMESTAMP declared types should map to String
+    @testset "DATETIME/TIMESTAMP juliatype" begin
+        # juliatype should return String regardless of the default
+        @test SQLite.juliatype("DATETIME") == String
+        @test SQLite.juliatype("TIMESTAMP") == String
+        @test SQLite.juliatype("DATETIME", Missing) == String
+        @test SQLite.juliatype("TIMESTAMP", Missing) == String
+        @test SQLite.juliatype("datetime") == String
+        @test SQLite.juliatype("timestamp") == String
+    end
+
+    @testset "DATETIME/TIMESTAMP strict mode with NULL" begin
+        db = SQLite.DB()
+        DBInterface.execute(db, "CREATE TABLE dt_test (id INTEGER, ts TIMESTAMP)")
+        # Insert NULL first, then a non-NULL value
+        DBInterface.execute(db, "INSERT INTO dt_test VALUES (1, NULL)")
+        DBInterface.execute(db, "INSERT INTO dt_test VALUES (2, '2024-01-01 00:00:00')")
+
+        # strict mode
+        tbl = DBInterface.execute(
+            DBInterface.prepare(db, "SELECT * FROM dt_test"),
+            ();
+            strict = true,
+        ) |> columntable
+        @test eltype(tbl.id) == Union{Missing,Int}
+        @test eltype(tbl.ts) == Union{Missing,String}
+        @test length(tbl.id) == 2
+        @test tbl.ts[1] === missing
+        @test tbl.ts[2] == "2024-01-01 00:00:00"
+
+        # non-strict
+        tbl2 = DBInterface.execute(db, "SELECT * FROM dt_test") |> columntable
+        @test eltype(tbl2.id) == Int
+        @test eltype(tbl2.ts) == Union{Missing,String}
+        @test length(tbl2.id) == 2
+        @test tbl2.ts[1] === missing
+        @test tbl2.ts[2] == "2024-01-01 00:00:00"
+    end
 end


### PR DESCRIPTION
## Problem

When a table has `DATETIME` or `TIMESTAMP` declared column types and the first row contains `NULL`, using `strict=true` causes a `MethodError` crash.

### Root cause

`juliatype(decl_typestr, default)` for DATETIME/TIMESTAMP returns `default` (the stored type of the first row). When the first row is NULL, `stored_type` is `Missing`, so the column type becomes `Union{Missing, Missing}` = `Missing`. In strict mode, `Tables.schema` uses this type directly, and `getvalue` calls `nonmissingtype(Missing)` = `Union{}`, leading to an ambiguous `sqlitevalue(::Type{Union{}}, ...)` dispatch.

### MWE

```julia
using SQLite, DBInterface, Tables

db = SQLite.DB()
DBInterface.execute(db, "CREATE TABLE test (id INTEGER, ts TIMESTAMP)")
DBInterface.execute(db, "INSERT INTO test VALUES (1, NULL)")
DBInterface.execute(db, "INSERT INTO test VALUES (2, '2024-01-01')")

stmt = DBInterface.prepare(db, "SELECT * FROM test")
columntable(DBInterface.execute(stmt, (); strict=true))
```

<details>
<summary>Full stacktrace</summary>

```
ERROR: MethodError: sqlitevalue(::Type{Union{}}, ::Ptr{SQLite.C.sqlite3_stmt}, ::Int64) is ambiguous.

Candidates:
  sqlitevalue(::Type{T}, handle, col) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}
    @ SQLite c:\ProgramData\DevDrive\.julia\dev\SQLite\src\SQLite.jl:544
  sqlitevalue(::Type{T}, handle, col) where T<:Union{Float16, Float32, Float64}
    @ SQLite c:\ProgramData\DevDrive\.julia\dev\SQLite\src\SQLite.jl:552
  sqlitevalue(::Type{T}, handle, col) where T<:AbstractString
    @ SQLite c:\ProgramData\DevDrive\.julia\dev\SQLite\src\SQLite.jl:556

Possible fix, define
  sqlitevalue(::Type{Union{}}, ::Any, ::Any)

Stacktrace:
 [1] getvalue(q::SQLite.Query{true}, col::Int64, rownumber::Int64, ::Type{Missing})
   @ SQLite c:\ProgramData\DevDrive\.julia\dev\SQLite\src\tables.jl:92
 [2] getcolumn
   @ c:\ProgramData\DevDrive\.julia\dev\SQLite\src\tables.jl:112 [inlined]
 [3] eachcolumns
   @ C:\ProgramData\DevDrive\.julia\packages\Tables\cRTb7\src\utils.jl:111 [inlined]
 [4] buildcolumns(schema::Tables.Schema{(:id, :ts), Tuple{Union{Missing, Int64}, Missing}}, rowitr::SQLite.Query{true})
   @ Tables C:\ProgramData\DevDrive\.julia\packages\Tables\cRTb7\src\fallbacks.jl:147
 [5] _columns
   @ C:\ProgramData\DevDrive\.julia\packages\Tables\cRTb7\src\fallbacks.jl:265 [inlined]
 [6] columns
   @ C:\ProgramData\DevDrive\.julia\packages\Tables\cRTb7\src\fallbacks.jl:258 [inlined]
 [7] columntable(itr::SQLite.Query{true})
   @ Tables C:\ProgramData\DevDrive\.julia\packages\Tables\cRTb7\src\namedtuples.jl:193
```

</details>

## Fix

Return `String` instead of `default` for DATETIME and TIMESTAMP declared types in `juliatype`. This matches datetime values are typically stored in SQLite (as TEXT, see also https://www.sqlite.org/datatype3.html).

The existing `FIXME` comments on these branches indicated this was a known issue.

## Results after fix

```julia
# strict mode (new behavior):
# (id = Union{Missing, Int64}[1, 2], ts = Union{Missing, String}[missing, "2024-01-01"])

# non-strict mode (default), unchanged before and after:
# (id = [1, 2], ts = Union{Missing, String}[missing, "2024-01-01"])
```

*Coded with Claude, manually edited and verified.*
