### PR TITLE
Scan multiple rows for determining type in strict mode

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -438,13 +438,35 @@ end
 # get julia type for given column of the given statement
 function juliatype(handle, col)
     stored_typeid = C.sqlite3_column_type(handle, col - 1)
+    did_row_scan = false
+    while stored_typeid == C.SQLITE_NULL
+        # Scan forward through the rows until we find a non-NULL value for this column
+        st = C.sqlite3_step(handle)
+        did_row_scan = true
+        if st == C.SQLITE_DONE
+            break
+        end
+        stored_typeid = C.sqlite3_column_type(handle, col - 1)
+        if stored_typeid != C.SQLITE_NULL
+            break
+        end
+    end
     if stored_typeid == C.SQLITE_BLOB
         # blobs are serialized julia types, so just try to deserialize it
+        # when forward scanning we need to use the current step to deserialize
         deser_val = sqlitevalue(Any, handle, col)
         # FIXME deserialized type have priority over declared type, is it fine?
+        if did_row_scan
+            C.sqlite3_reset(handle)
+            C.sqlite3_step(handle)
+        end
         return typeof(deser_val)
     else
         stored_type = juliatype(stored_typeid)
+    end
+    if did_row_scan
+        C.sqlite3_reset(handle)
+        C.sqlite3_step(handle)
     end
     decl_typestr = C.sqlite3_column_decltype(handle, col - 1)
     if decl_typestr != C_NULL

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -150,6 +150,7 @@ The resultset iterator supports the [Tables.jl](https://github.com/JuliaData/Tab
 like `DataFrame(results)`, `CSV.write("results.csv", results)`, etc.
 
 Passing `strict=true` to `DBInterface.execute` will cause the resultset iterator to return values of the exact type specified by SQLite.
+While more type-stable, determining the exact types of the results can be more expensive as it will iterate through each column to find the first non-NULL value to determine the type.
 """
 function DBInterface.execute(
     stmt::Stmt,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1067,8 +1067,8 @@ end
     tbl = DBInterface.execute(db, "select x from tmp") |> columntable
     @test isequal(tbl.x, [missing, :a])
 
-    # Symbol in TEXT type doesn't work
-    # when strict and first row is NULL (the serialized bytes are interpreted as a string)
+    # Symbol in TEXT type now works even when strict and first row is NULL,
+    # because juliatype scans multiple rows to find the actual stored type (BLOB)
     tbl =
         DBInterface.execute(
             DBInterface.prepare(db, "select x from tmp"),
@@ -1076,7 +1076,7 @@ end
             strict = true,
         ) |> columntable
     @test tbl.x[1] === missing
-    @test tbl.x[2] isa String  # Symbol gets incorrectly deserialized as garbage string
+    @test tbl.x[2] === :a
 
     # Symbol in BLOB type does work strict
     db = SQLite.DB()


### PR DESCRIPTION
Alternative to #348.

Instead of trying to find a good default type for when the first row is NULL in strict mode, this PR scans the whole column until it finds a non-NULL value and uses that to derive the type. This not only fixes the issue described in #348, but also the downside of #346 that would corrupt Julia types in strict mode for columns starting with NULL (i.e. a symbol becoming a string).