### PR TITLE
Prevent type inference from re-executing DDL

### DIFF
--- a/src/SQLite.jl
+++ b/src/SQLite.jl
@@ -478,16 +478,14 @@ end
 #int sqlite3_bind_value(sqlite3_stmt*, int, const sqlite3_value*);
 
 # get julia type for given column of the given statement
-function juliatype(handle, col)
+function juliatype(handle, col, scanrows::Bool = false)
     stored_typeid = C.sqlite3_column_type(handle, col - 1)
     did_row_scan = false
-    while stored_typeid == C.SQLITE_NULL
+    while scanrows && stored_typeid == C.SQLITE_NULL
         # Scan forward through the rows until we find a non-NULL value for this column
         st = C.sqlite3_step(handle)
         did_row_scan = true
-        if st == C.SQLITE_DONE
-            break
-        end
+        st == C.SQLITE_ROW || break
         stored_typeid = C.sqlite3_column_type(handle, col - 1)
         if stored_typeid != C.SQLITE_NULL
             break

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -175,7 +175,7 @@ function DBInterface.execute(
             nm = newnm
         end
         header[i] = nm
-        types[i] = Union{juliatype(handle, i),Missing}
+        types[i] = Union{juliatype(handle, i, strict && status == C.SQLITE_ROW),Missing}
     end
     return Query{strict}(
         stmt,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -889,6 +889,19 @@ end
     end
 
     @testset "strict mode" begin
+        @testset "Issue #353: ALTER TABLE on a STRICT table" begin
+            for strict in (false, true)
+                db = SQLite.DB()
+                DBInterface.execute(db, "CREATE TABLE t (a INTEGER) STRICT")
+                stmt = DBInterface.prepare(db, "ALTER TABLE t ADD COLUMN b INTEGER")
+                query = DBInterface.execute(stmt, (); strict = strict)
+
+                @test isempty(query)
+                info = DBInterface.execute(db, "PRAGMA table_info(t)") |> columntable
+                @test info.name == ["a", "b"]
+            end
+        end
+
         @testset "PR #343: strict (and only strict) tables should error if types don't match" begin
             db = SQLite.DB()
 


### PR DESCRIPTION
## Summary

- restrict forward type inference to strict queries that produced a row
- stop the type scan for every status other than `SQLITE_ROW`
- cover `ALTER TABLE ... ADD COLUMN` on strict tables in normal and strict result modes

SQLite can expose a hidden result column for this schema change. SQLite.jl previously re-stepped the completed statement while inferring that column's type. The schema change then ran again, returned `SQLITE_ERROR`, and the scan loop continued forever.

## Validation

- Julia 1.9: 227/227 tests pass
- Julia 1.10: 227/227 tests pass
- Julia 1.12: 227/227 tests pass
- documentation builds
- `Test.detect_ambiguities(SQLite; recursive=true)` reports no ambiguities

Fixes #353

Co-authored by Codex